### PR TITLE
Korrektur Fehler Denton-Cholette (h=0)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 Changes for R-package tempdisagg
 
+blabla
+
 Version 0.22 (Jun 8th, 2013)
 
 


### PR DESCRIPTION
In td.sub.R hatte es in der Funktion SubDenton einen Fehler, der sich bei h=0 und method=denton-cholette in den Werten zur ersten Periode auswirkte (mit und ohne Indikator).
Zudem könnte man noch etwas Redundanz eliminieren: die Zeilen 176-178 entsprechen 183-185 und könnten nach Zeile 186 nur einmal eingefügt werden.
